### PR TITLE
Set card background inside dialogs

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -9,3 +9,9 @@ import Navbar from '~/components/navbar.vue'
   </v-app>
 </template>
 
+<style>
+.v-dialog .v-card {
+  background-color: red;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- apply global style so v-cards inside v-dialogs get a red background

## Testing
- `npm run build` *(fails: `nuxt: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a030d1124832bb709c40bf18d9757