### PR TITLE
Add Ask stories to navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ GET https://hacker-news.firebaseio.com/v0/item/<id>.json
 
 Results are displayed in the UI and clicking a story opens its details in a dialog.
 
+Use the navigation bar to switch between Top, New, Job and Ask stories.
+

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -5,6 +5,7 @@
     <v-list-item @click="updateStoryType('topstories')">Top</v-list-item>
     <v-list-item @click="updateStoryType('newstories')">New</v-list-item>
     <v-list-item @click="updateStoryType('jobstories')">Jobs</v-list-item>
+    <v-list-item @click="updateStoryType('askstories')">Ask</v-list-item>
   </v-app-bar>
 </template>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,15 +8,21 @@ const route = useRoute();
 const stories = ref<Story[]>([])
 const loading = ref(true)
 
+const currentType = computed(() => (route.query.type as string) || 'topstories');
+const titleMap: Record<string, string> = {
+  topstories: 'Top Stories',
+  newstories: 'New Stories',
+  jobstories: 'Job Stories',
+  askstories: 'Ask Stories'
+};
+const headerTitle = computed(() => titleMap[currentType.value] || 'Stories');
+
 const modalOpen = ref(false);
 const selectedStory = ref<Story | null>();
 
 watchEffect(async () => {
   loading.value = true;
-  const type = route.query.type || "topstories";
-
-  const result = await useStories(type);
-
+  const result = await useStories(currentType.value as any);
   stories.value = result.stories.value;
   loading.value = result.loading.value;
 })
@@ -31,7 +37,7 @@ const toggleModal = (story: Story) => {
 
 <template>
   <v-container class="py-6 mt-12">
-    <h2 class="text-h5 mb-4">Top Stories</h2>
+    <h2 class="text-h5 mb-4">{{ headerTitle }}</h2>
 
     <div v-if="loading">
       <v-skeleton-loader 


### PR DESCRIPTION
## Summary
- link Ask stories via navbar
- compute story type header based on route
- document Ask stories in README

## Testing
- `apt-get update` *(fails: internet access blocked)*
- `npx eslint . --ext .ts,.vue` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0ee6d378832ba4f46afc1c84332a