### PR TITLE
Add image search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ Results are displayed in the UI and clicking a story opens its details in a dial
 
 Use the navigation bar to switch between Top, New, Job and Ask stories.
 
+## Image Search API
+
+Story dialogs display a related photo fetched from the free [Unsplash](https://unsplash.com) API.  Set an access key in an `.env` file before running the app:
+
+```bash
+UNSPLASH_ACCESS_KEY=your_access_key
+```
+

--- a/composables/useStories.ts
+++ b/composables/useStories.ts
@@ -5,20 +5,46 @@ export interface Story {
     score: number
     url: string
     descendants?: number
+    imageUrl?: string
 }
 
 export const useStories = async (type: 'topstories' | 'newstories' | 'beststories' | 'askstories' | 'showstories' | 'jobstories') => {
     const stories = ref<Story[]>([])
-    const top20 = ref<number[]>([]);
-    const loading = ref(true);
+    const top20 = ref<number[]>([])
+    const loading = ref(true)
+    const {
+      public: { unsplashAccessKey },
+    } = useRuntimeConfig()
+
+    const fetchImage = async (keywords: string) => {
+      try {
+        const q = encodeURIComponent(keywords)
+        const res = await fetch(
+          `https://api.unsplash.com/photos/random?query=${q}&client_id=${unsplashAccessKey}`
+        )
+        if (!res.ok) return undefined
+        const img = await res.json()
+        return img.urls.small as string
+      } catch (err) {
+        console.error('Failed to fetch image:', err)
+        return undefined
+      }
+    }
 
     try {
         const response = await fetch (`https://hacker-news.firebaseio.com/v0/${type}.json`);
         const data = await response.json();
         top20.value = data.slice(0,20);
-        const storyPromises = top20.value.map((id) => fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`).then((res) => res.json()))
-        const storyData = await Promise.all(storyPromises);
-        stories.value = storyData;
+        const storyPromises = top20.value.map(async (id) => {
+          const story: Story = await fetch(
+            `https://hacker-news.firebaseio.com/v0/item/${id}.json`
+          ).then((res) => res.json())
+          const keywords = story.title.split(' ').slice(0, 3).join(' ')
+          story.imageUrl = await fetchImage(keywords)
+          return story
+        })
+        const storyData = await Promise.all(storyPromises)
+        stories.value = storyData
     }
     catch (error) {
         console.error('Failed to load stories:', error)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,5 +13,11 @@ export default defineNuxtConfig({
     },
   },
 
+  runtimeConfig: {
+    public: {
+      unsplashAccessKey: process.env.UNSPLASH_ACCESS_KEY,
+    },
+  },
+
   compatibilityDate: '2025-04-19',
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -70,6 +70,12 @@ const toggleModal = (story: Story) => {
       </div>
       <v-dialog style="max-width: 1000px;" v-model="modalOpen">
         <v-card style="align-items: center;">
+          <v-img
+            v-if="selectedStory?.imageUrl"
+            :src="selectedStory.imageUrl"
+            aspect-ratio="16/9"
+            class="mb-2"
+          />
           <v-card-title>
             <a :href="selectedStory?.url" target="_blank"> {{ selectedStory?.title }} </a>
           </v-card-title>


### PR DESCRIPTION
## Summary
- add Unsplash access key to runtime config
- fetch a related image for each story
- display an image in the dialog card
- document Unsplash key in README

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a190b306c832b88d4d2427fc9c4f4