### PR TITLE
Setup Vitest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ Results are displayed in the UI and clicking a story opens its details in a dial
 
 Use the navigation bar to switch between Top, New, Job and Ask stories.
 
+## Running Tests
+
+Unit tests are written with [Vitest](https://vitest.dev/).  Execute all tests with:
+
+```bash
+npm test
+```
+
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.11.0",
@@ -17,5 +18,8 @@
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
     "vuetify": "^3.8.2"
+  },
+  "devDependencies": {
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/useStories.test.ts
+++ b/tests/useStories.test.ts
@@ -1,0 +1,28 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { useStories } from '../composables/useStories'
+
+const exampleStory = {
+  id: 1,
+  title: 'Example',
+  by: 'tester',
+  score: 10,
+  url: 'https://example.com'
+}
+
+describe('useStories', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('fetches stories and returns them', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve([1]) } as any)
+      .mockResolvedValueOnce({ json: () => Promise.resolve(exampleStory) } as any)
+
+    const { stories, loading } = await useStories('topstories')
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(stories.value).toEqual([exampleStory])
+    expect(loading.value).toBe(false)
+  })
+})

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["tests/**/*.ts", "tests/**/*.tsx", "tests/**/*.vue"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest config
- add test script and dev dependency
- provide example unit test for `useStories`
- document how to run tests

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a23693070832bb523f773fab165c6